### PR TITLE
Added delete branch on close PR workflow

### DIFF
--- a/.github/workflows/delete_branch.yml
+++ b/.github/workflows/delete_branch.yml
@@ -1,0 +1,15 @@
+name: Delete Merged Branches
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  delete_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Pull and Delete Branch
+        uses: peter-evans/close-pull@v1
+        with:
+          pull-request-number: 1
+          comment: Closing pull request and deleting it's branch
+          delete-branch: true

--- a/.github/workflows/delete_branch.yml
+++ b/.github/workflows/delete_branch.yml
@@ -7,9 +7,7 @@ jobs:
   delete_branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Close Pull and Delete Branch
-        uses: peter-evans/close-pull@v1
-        with:
-          pull-request-number: 1
-          comment: Closing pull request and deleting it's branch
-          delete-branch: true
+      - name: delete branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#17 

This workflow deletes the branch when the PR is closed, it gives a comment about the same. Also, deleting branches will fail silently for pull requests to public repositories from forks.