### PR TITLE
Implemented a better way to hide the keyboard properly

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,18 +16,26 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Retro Shopping',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-          // primarySwatch: Colors.blue,
-          scaffoldBackgroundColor: RelicColors.backgroundColor,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-          textTheme: GoogleFonts.poppinsTextTheme(Theme.of(context).textTheme)),
-      routes: <String, WidgetBuilder>{
-        '/dashboard': (BuildContext context) => Dashboard(),
+    return GestureDetector(
+      onTap: (){
+        final FocusScopeNode currentFocus = FocusScope.of(context);
+        if (!currentFocus.hasPrimaryFocus && currentFocus.focusedChild != null) {
+          FocusManager.instance.primaryFocus.unfocus();
+        }
       },
-      home: Splash(),
+      child: MaterialApp(
+        title: 'Retro Shopping',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+            // primarySwatch: Colors.blue,
+            scaffoldBackgroundColor: RelicColors.backgroundColor,
+            visualDensity: VisualDensity.adaptivePlatformDensity,
+            textTheme: GoogleFonts.poppinsTextTheme(Theme.of(context).textTheme)),
+        routes: <String, WidgetBuilder>{
+          '/dashboard': (BuildContext context) => Dashboard(),
+        },
+        home: Splash(),
+      ),
     );
   }
 }


### PR DESCRIPTION
Problem:
When the keyboard pops up after tapping on a textfield, it cannot be closed by tapping on any part of the screen. The only way is to tap the back button. This commit resolves the issue

Closes #37 

Fix:
Added gesturedetector to main.dart, where materialapp is the gestoredetector's child.

Video showing the fix:

https://user-images.githubusercontent.com/68701271/110483124-6d1c5d00-810f-11eb-9993-eb339c86154c.mp4

