### PR TITLE
Fixed issue#39 gave flex to widget to make it fit small screensize

### DIFF
--- a/lib/widgets/payment/order_item.dart
+++ b/lib/widgets/payment/order_item.dart
@@ -99,32 +99,37 @@ class OrderItem extends StatelessWidget {
               ),
               Row(
                 children: <Widget>[
-                  Container(
-                    padding:
-                        const EdgeInsets.symmetric(vertical: 5, horizontal: 5),
-                    decoration: BoxDecoration(
-                        border: Border.all(color: Colors.white),
-                        borderRadius: BorderRadius.circular(8),
-                        color: RelicColors.backgroundColor),
-                    child: const Text('DETAILS',
-                        style: TextStyle(fontSize: 13, color: Colors.white)),
+                  Flexible(
+                    child: Container(
+                      padding:
+                          const EdgeInsets.symmetric(vertical: 5, horizontal: 7),
+                      decoration: BoxDecoration(
+                          border: Border.all(color: Colors.white),
+                          borderRadius: BorderRadius.circular(8),
+                          color: RelicColors.backgroundColor),
+                      child: const Text('DETAILS',
+                          style: TextStyle(fontSize: 12, color: Colors.white)),
+                    ),
                   ),
                   const SizedBox(
-                    width: 10,
+                    width: 9,
                   ),
                   if (delivered)
                     Container()
                   else
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 5, horizontal: 5),
-                      decoration: BoxDecoration(
-                          border: Border.all(color: Colors.white),
-                          borderRadius: BorderRadius.circular(8),
-                          color: RelicColors.warningColor),
-                      child: const Text('CANCEL',
-                          style: TextStyle(fontSize: 13, color: Colors.white)),
-                    ),
+                    Flexible(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 5, horizontal: 7),
+                          decoration: BoxDecoration(
+                              border: Border.all(color: Colors.white),
+                              borderRadius: BorderRadius.circular(8),
+                              color: RelicColors.warningColor),
+                          child: const Text('CANCEL',
+                              style: TextStyle(fontSize: 12, color: Colors.white)),
+                        ),
+                    )
+
                 ],
               )
             ],


### PR DESCRIPTION
### Related Issue
- Fixes # 39

### Proposed Changes
Added flex to the widget so it won't throw overflow error on small screen sizes.

### Additional Info
As you asked @himanshusharma89 i've added flex to the widgets so now it won't throw overflow issues for any screen size


### Checklist
- [x] Tested
- [x] No Conflicts
- [x] Change In Code
- [ ] Change In Documentation

### Screenshots
Before this PR            | After this PR
:-----------------------: | :-----------------------:
![image](https://user-images.githubusercontent.com/66346161/110740314-dd82c580-8258-11eb-9cc2-e951b27ad305.png)| ![image](https://user-images.githubusercontent.com/66346161/110740271-ce9c1300-8258-11eb-87fe-c638d46e46ed.png)
