### PR TITLE
Outsourced Drawer and Drawer Item widgets

### DIFF
--- a/lib/model/product.dart
+++ b/lib/model/product.dart
@@ -1,11 +1,4 @@
 class Product {
-  final String text;
-  final String owner;
-  final String amount;
-  final String image;
-  final String seller;
-  final int height;
-
   Product({
     this.text,
     this.owner,
@@ -14,4 +7,11 @@ class Product {
     this.seller,
     this.height,
   });
+
+  final String text;
+  final String owner;
+  final String amount;
+  final String image;
+  final String seller;
+  final int height;
 }

--- a/lib/views/drawer_widget.dart
+++ b/lib/views/drawer_widget.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../widgets/drawer_item.dart';
+
+class DrawerWidget extends StatelessWidget {
+  const DrawerWidget({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: const EdgeInsets.only(top: 20.0),
+        children: <Widget>[
+          DrawerItem(icon: Icons.person, title: 'ABOUT', onTap: () {}),
+          DrawerItem(
+            icon: Icons.shopping_cart,
+            title: 'CART',
+            onTap: () {},
+          ),
+          DrawerItem(
+            icon: Icons.list,
+            title: 'WISHLIST',
+            onTap: () {},
+          ),
+          DrawerItem(
+            icon: Icons.category,
+            title: 'PRODUCTS',
+            onTap: () {},
+          ),
+          DrawerItem(
+            icon: Icons.logout,
+            title: 'LOG OUT',
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:retro_shopping/helpers/app_icons.dart';
 import 'package:retro_shopping/helpers/constants.dart';
+import 'package:retro_shopping/views/drawer_widget.dart';
 import 'package:retro_shopping/widgets/retro_button.dart';
 
 class Home extends StatelessWidget {
@@ -209,80 +210,4 @@ class Home extends StatelessWidget {
       ],
     );
   }
-}
-
-class DrawerWidget extends StatelessWidget {
-  const DrawerWidget({
-    Key key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Drawer(
-      child: ListView(
-        padding: const EdgeInsets.only(top: 20.0),
-        children: <Widget>[
-          _createDrawerItem(icon: Icons.person, title: 'ABOUT', onTap: () {}),
-          _createDrawerItem(
-            icon: Icons.shopping_cart,
-            title: 'CART',
-            onTap: () {},
-          ),
-          _createDrawerItem(
-            icon: Icons.list,
-            title: 'WISHLIST',
-            onTap: () {},
-          ),
-          _createDrawerItem(
-            icon: Icons.category,
-            title: 'PRODUCTS',
-            onTap: () {},
-          ),
-          _createDrawerItem(
-            icon: Icons.logout,
-            title: 'LOG OUT',
-            onTap: () {},
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-Widget _createDrawerItem(
-    {IconData icon, String title, GestureTapCallback onTap}) {
-  return ListTile(
-    title: Row(
-      children: <Widget>[
-        Icon(
-          icon,
-          color: RelicColors.backgroundColor,
-          size: 40.0,
-        ),
-        Expanded(
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: 12.0,
-              vertical: 30.0,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: <Widget>[
-                Text(
-                  title,
-                  style: const TextStyle(
-                    fontFamily: 'Pixer',
-                    color: RelicColors.backgroundColor,
-                    fontSize: 18.0,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        )
-      ],
-    ),
-    onTap: onTap,
-  );
 }

--- a/lib/widgets/drawer_item.dart
+++ b/lib/widgets/drawer_item.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:retro_shopping/helpers/constants.dart';
+
+class DrawerItem extends StatelessWidget {
+  const DrawerItem({
+    this.icon,
+    this.title,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final GestureTapCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Row(
+        children: <Widget>[
+          Icon(
+            icon,
+            color: RelicColors.backgroundColor,
+            size: 30.0,
+          ),
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12.0,
+                vertical: 20.0,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontFamily: 'Pixer',
+                      color: RelicColors.backgroundColor,
+                      fontSize: 15.0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          )
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+}


### PR DESCRIPTION
### Related Issue
- Fixes #99

### Proposed Changes
- Outsourced DrawerWidget to a new file called drawer_widget.dart in views folder
- Outsourced DrawerItem to a new file called drawer_item.dart in widgets folder
- Fixed a minor warning in Product.dart file in the models folder
- Cleaned the home.dart file
