### PR TITLE
'Wishlist-Screen'

### DIFF
--- a/lib/views/Wishlist.dart
+++ b/lib/views/Wishlist.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:retro_shopping/helpers/constants.dart';
+import 'package:retro_shopping/widgets/retro_button.dart';
+import 'package:retro_shopping/widgets/payment/order_item.dart';
+
+class Wishlist extends StatelessWidget {
+  const Wishlist({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final double height = MediaQuery.of(context).size.height;
+    final double width = MediaQuery.of(context).size.width;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const SizedBox(height: 20),
+        Center(
+          child: Stack(
+            children: <Widget>[
+              Container(
+                width: MediaQuery.of(context).size.width * 0.88 + 5,
+                height: 431,
+                decoration: const BoxDecoration(color: Colors.black),
+              ),
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(vertical: 16, horizontal: 12),
+                width: MediaQuery.of(context).size.width * 0.87,
+                height: 420,
+                decoration:
+                    const BoxDecoration(color: RelicColors.primaryColor),
+                child: ListView(
+                  shrinkWrap: true,
+                  primary: false,
+                  children: const <Widget>[
+                    OrderItem(
+                        title: 'EDI TURNTABLE',
+                        ordered: 'by Tony Stark',
+                        status: 'OUT OF STOCK',
+                        image: 'assets/items/4.png'),
+
+                    Divider(
+                      color: Colors.white,
+                    ),
+                    OrderItem(
+                      title: 'TATUNG EINSTEIN',
+                      ordered: 'by Chris Evans',
+                      status: 'OUT OF STOCK',
+                      image: 'assets/items/1.png',
+                    ),
+                    // Divider(color: Clors.w,),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class WishlistScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final double height = MediaQuery.of(context).size.height;
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 18),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(
+              height: height * 0.16,
+            ),
+            const Wishlist(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class Wishlistscreen extends StatefulWidget {
+  Wishlistscreen({Key key}) : super(key: key);
+
+  @override
+  _WishlistscreenState createState() => _WishlistscreenState();
+}
+
+class _WishlistscreenState extends State<Wishlistscreen> {
+  @override
+  Widget build(BuildContext context) {
+    final double height = MediaQuery.of(context).size.height;
+    final double width = MediaQuery.of(context).size.width;
+    return Container(
+      child: Scaffold(
+        appBar: AppBar(
+          elevation: 0,
+          centerTitle: true,
+          title: RetroButton(
+            upperColor: Colors.white,
+            lowerColor: Colors.black,
+            height: height * 0.046,
+            width: width * 0.35,
+            borderColor: Colors.white,
+            child: const Center(
+              child: Text(
+                '♥ WISHLIST',
+                style: TextStyle(
+                  fontFamily: 'pix M 8pt',
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: RelicColors.backgroundColor,
+                ),
+                // textAlign: TextAlign.left,
+              ),
+            ),
+          ),
+          leading: GestureDetector(
+            onTap: () {
+              Navigator.of(context).pop();
+            },
+            child: Container(
+              padding: const EdgeInsets.only(left: 10, top: 10),
+              child: RetroButton(
+                upperColor: Colors.white,
+                lowerColor: Colors.black,
+                height: height * 0.035,
+                width: width * 0.44,
+                borderColor: Colors.white,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: const <Widget>[
+                    Icon(
+                      Icons.arrow_back,
+                      size: 20,
+                      color: RelicColors.primaryBlack,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          backgroundColor: RelicColors.backgroundColor,
+        ),
+        backgroundColor: RelicColors.backgroundColor,
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                SizedBox(
+                  height: height * 0.01,
+                ),
+                const Wishlist(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/drawer_widget.dart
+++ b/lib/views/drawer_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+//import 'package:retro_shopping/views/profile.dart';
 import '../widgets/drawer_item.dart';
+import './Wishlist.dart';
 
 class DrawerWidget extends StatelessWidget {
   const DrawerWidget({
@@ -21,7 +23,12 @@ class DrawerWidget extends StatelessWidget {
           DrawerItem(
             icon: Icons.list,
             title: 'WISHLIST',
-            onTap: () {},
+            onTap: () {
+               Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => Wishlistscreen()),
+              );
+            },
           ),
           DrawerItem(
             icon: Icons.category,


### PR DESCRIPTION
### Related Issue: Wishlist Screen
- Fixed #35 .

### Proposed Changes
- Created ```Wishlist.dart``` in the views folder to create a new screen that contains wishlist
- Assigned Navigator in ```drawer_item.dart``` to navigate to Wishlist  Screen

### Additional Information
- The Change suggests a Wishlist screen as proposed by the issue #35 .

### Checklist
- [x] Tested
- [x] No Conflicts
- [x] Change In Code
- [ ] Change In Documentation

### Screenshots
Before this PR            | After this PR
:-----------------------: | :-----------------------:
** This is a new Screen** | ![WhatsApp Image 2021-03-14 at 5 09 47 PM](https://user-images.githubusercontent.com/55244625/111067745-99f3ba00-84eb-11eb-8fe0-a6da66541399.jpeg)
