### PR TITLE
Added show and hide password functionality

### DIFF
--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -30,6 +30,8 @@ class LoginScreenState extends State<LoginScreen> {
 
   bool _loading = false;
 
+  bool showPassword = true;
+
   @override
   void initState() {
     super.initState();
@@ -102,7 +104,7 @@ class LoginScreenState extends State<LoginScreen> {
                           enabled: true,
                           textInputAction: TextInputAction.next,
                           decoration:
-                              textFieldDecoration(hintText: 'Email Address'),
+                              textFieldDecoration(hintText: 'Email Address',),
                           controller: _emailController,
                           validator: (String value) => _authenticationService
                               .userEmailValidation(value, errorMessage),
@@ -122,11 +124,19 @@ class LoginScreenState extends State<LoginScreen> {
                         child: TextFormField(
                           focusNode: _password,
                           keyboardType: TextInputType.visiblePassword,
-                          obscureText: true,
+                          obscureText: showPassword,
                           enabled: true,
                           textInputAction: TextInputAction.done,
                           decoration: textFieldDecoration(
                             hintText: 'Password',
+                            suffixIcon: IconButton(
+                              icon: showPassword ?  const Icon(Icons.visibility) :  const Icon(Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  showPassword = !showPassword ;
+                                });
+                              },//for show and hide password
+                            ),
                           ),
                           validator: (String value) => _authenticationService
                               .userPasswordValidation(value, errorMessage),

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -21,6 +21,9 @@ class SignUpScreenState extends State<SignUpScreen> {
   final TextEditingController _confirmPasswordController =
       TextEditingController();
 
+  bool showPassword = true;
+  bool showConfirmPassword = true;
+
   String email;
   String password;
   String errorMessage;
@@ -108,7 +111,7 @@ class SignUpScreenState extends State<SignUpScreen> {
                           enabled: true,
                           textInputAction: TextInputAction.next,
                           decoration:
-                              textFieldDecoration(hintText: 'Email Address'),
+                              textFieldDecoration(hintText: 'Email Address',),
                           controller: _emailController,
                           validator: (String value) => _authenticationService
                               .userEmailValidation(value, errorMessage),
@@ -128,11 +131,17 @@ class SignUpScreenState extends State<SignUpScreen> {
                           child: TextFormField(
                             focusNode: _password,
                             keyboardType: TextInputType.visiblePassword,
-                            obscureText: true,
+                            obscureText: showPassword,
                             enabled: true,
                             textInputAction: TextInputAction.next,
                             decoration: textFieldDecoration(
                               hintText: 'Password',
+                              suffixIcon: IconButton(
+                                icon: showPassword ? const Icon(Icons.visibility) : const Icon(Icons.visibility_off),
+                                onPressed: () {
+                                  setState(() {showPassword = !showPassword;});
+                                },//for show and hide password
+                              ),
                             ),
                             validator: (String value) => _authenticationService
                                 .userPasswordValidation(value, errorMessage),
@@ -151,11 +160,17 @@ class SignUpScreenState extends State<SignUpScreen> {
                         child: TextFormField(
                           focusNode: _confirm,
                           keyboardType: TextInputType.visiblePassword,
-                          obscureText: true,
+                          obscureText: showConfirmPassword,
                           enabled: true,
                           textInputAction: TextInputAction.done,
                           decoration: textFieldDecoration(
                             hintText: 'Confirm Password',
+                            suffixIcon: IconButton(
+                              icon: showConfirmPassword ? const Icon(Icons.visibility) : const Icon(Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {showConfirmPassword = !showConfirmPassword;});
+                              },//for show and hide password
+                            ),
                           ),
                           validator: (String value) => _authenticationService
                               .userConfirmPasswordValidation(

--- a/lib/widgets/text_field_decoration.dart
+++ b/lib/widgets/text_field_decoration.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 
-InputDecoration textFieldDecoration({String hintText, Icon icon}) {
+InputDecoration textFieldDecoration({String hintText, Icon icon, IconButton suffixIcon }) {
   return InputDecoration(
     prefixIcon: icon,
     hintText: hintText,
     filled: true,
     fillColor: Colors.white,
     border: InputBorder.none,
+    suffixIcon: suffixIcon
   );
 }


### PR DESCRIPTION
### Related Issue
- Fixes #223.

### Proposed Changes
- Added one named parameter suffixIcon in text_field_decoration.dart file
- Added 2 icons (Visibility and non-visibility) in login and signup screens using setState.

### Checklist
- [x] Tested
- [x] No Conflicts
- [x] Change In Code
- [ ] Change In Documentation
- [x] Follows linting rules

### Screenshots
![Screenshot_1620053950](https://user-images.githubusercontent.com/70088044/116895049-66fab680-ac50-11eb-8f84-6bdc6ddec1f9.png)


![Screenshot_1620053980](https://user-images.githubusercontent.com/70088044/116895128-7e39a400-ac50-11eb-93e3-6c44da651fef.png)
