### PR TITLE
Reversed Visibility Icons in Auth Forms , Back Link to Login Page from Sigup page , Fit type of profile photo

### DIFF
--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -19,7 +19,7 @@ class LoginScreenState extends State<LoginScreen> {
 
   String? _email, _password;
   FocusNode? _emailFocusNode, _passwordFocusNode, _loginFocusNode;
-  bool _loading = false, _showPassword = true;
+  bool _loading = false, _isPasswordHidden = true;
 
   @override
   void initState() {
@@ -124,19 +124,19 @@ class LoginScreenState extends State<LoginScreen> {
                             child: TextFormField(
                               focusNode: _passwordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: _showPassword,
+                              obscureText: _isPasswordHidden,
                               enabled: true,
                               textInputAction: TextInputAction.done,
                               decoration: textFieldDecoration(
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
-                                  icon: _showPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                  icon: _isPasswordHidden
+                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(
                                       () {
-                                        _showPassword = !_showPassword;
+                                        _isPasswordHidden = !_isPasswordHidden;
                                       },
                                     );
                                   }, //for show and hide password

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -131,8 +131,8 @@ class LoginScreenState extends State<LoginScreen> {
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
                                   icon: _showPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                      ? const Icon(Icons.visibility_off , color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility , color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(
                                       () {

--- a/lib/views/auth/login_view.dart
+++ b/lib/views/auth/login_view.dart
@@ -19,7 +19,7 @@ class LoginScreenState extends State<LoginScreen> {
 
   String? _email, _password;
   FocusNode? _emailFocusNode, _passwordFocusNode, _loginFocusNode;
-  bool _loading = false, _isPasswordHidden = true;
+  bool _loading = false, _showPassword = true;
 
   @override
   void initState() {
@@ -124,19 +124,19 @@ class LoginScreenState extends State<LoginScreen> {
                             child: TextFormField(
                               focusNode: _passwordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: _isPasswordHidden,
+                              obscureText: _showPassword,
                               enabled: true,
                               textInputAction: TextInputAction.done,
                               decoration: textFieldDecoration(
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
-                                  icon: _isPasswordHidden
-                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
-                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
+                                  icon: _showPassword
+                                      ? const Icon(Icons.visibility)
+                                      : const Icon(Icons.visibility_off),
                                   onPressed: () {
                                     setState(
                                       () {
-                                        _isPasswordHidden = !_isPasswordHidden;
+                                        _showPassword = !_showPassword;
                                       },
                                     );
                                   }, //for show and hide password

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:relic_bazaar/helpers/constants.dart';
 import 'package:relic_bazaar/helpers/input_validators.dart';
 import 'package:relic_bazaar/widgets/retro_button.dart';
 import 'package:relic_bazaar/services/auth_service.dart';
@@ -16,7 +17,7 @@ class SignUpScreen extends StatefulWidget {
 class SignUpScreenState extends State<SignUpScreen> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
-  bool showPassword = true, showConfirmPassword = true, _loading = false;
+  bool isPasswordHidden = true, isConfirmPasswordHidden = true, _loading = false;
   String? _email, _password, _confirmPassword;
   FocusNode? _emailFocusNode,
       _passwordFocusNode,
@@ -127,18 +128,18 @@ class SignUpScreenState extends State<SignUpScreen> {
                             child: TextFormField(
                               focusNode: _passwordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: showPassword,
+                              obscureText: isPasswordHidden,
                               enabled: true,
                               textInputAction: TextInputAction.next,
                               decoration: textFieldDecoration(
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
-                                  icon: showPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                  icon: isPasswordHidden
+                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(() {
-                                      showPassword = !showPassword;
+                                      isPasswordHidden = !isPasswordHidden;
                                     });
                                   }, //for show and hide password
                                 ),
@@ -166,18 +167,18 @@ class SignUpScreenState extends State<SignUpScreen> {
                             child: TextFormField(
                               focusNode: _confirmPasswordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: showConfirmPassword,
+                              obscureText: isConfirmPasswordHidden,
                               enabled: true,
                               textInputAction: TextInputAction.done,
                               decoration: textFieldDecoration(
                                 hintText: 'Confirm Password',
                                 suffixIcon: IconButton(
-                                  icon: showConfirmPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                  icon: isConfirmPasswordHidden
+                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(() {
-                                      showConfirmPassword = !showConfirmPassword;
+                                      isConfirmPasswordHidden = !isConfirmPasswordHidden;
                                     });
                                   }, //for show and hide password
                                 ),
@@ -266,6 +267,17 @@ class SignUpScreenState extends State<SignUpScreen> {
                                 child: Image.asset(
                                   'assets/items/google.png',
                                 ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        Center(
+                          child: TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text(
+                              'Login',
+                              style: TextStyle(
+                                color: Colors.white,
                               ),
                             ),
                           ),

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
-import 'package:relic_bazaar/helpers/constants.dart';
 import 'package:relic_bazaar/helpers/input_validators.dart';
 import 'package:relic_bazaar/widgets/retro_button.dart';
 import 'package:relic_bazaar/services/auth_service.dart';
@@ -17,7 +16,7 @@ class SignUpScreen extends StatefulWidget {
 class SignUpScreenState extends State<SignUpScreen> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
-  bool isPasswordHidden = true, isConfirmPasswordHidden = true, _loading = false;
+  bool showPassword = true, showConfirmPassword = true, _loading = false;
   String? _email, _password, _confirmPassword;
   FocusNode? _emailFocusNode,
       _passwordFocusNode,
@@ -128,18 +127,18 @@ class SignUpScreenState extends State<SignUpScreen> {
                             child: TextFormField(
                               focusNode: _passwordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: isPasswordHidden,
+                              obscureText: showPassword,
                               enabled: true,
                               textInputAction: TextInputAction.next,
                               decoration: textFieldDecoration(
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
-                                  icon: isPasswordHidden
-                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
-                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
+                                  icon: showPassword
+                                      ? const Icon(Icons.visibility)
+                                      : const Icon(Icons.visibility_off),
                                   onPressed: () {
                                     setState(() {
-                                      isPasswordHidden = !isPasswordHidden;
+                                      showPassword = !showPassword;
                                     });
                                   }, //for show and hide password
                                 ),
@@ -167,18 +166,18 @@ class SignUpScreenState extends State<SignUpScreen> {
                             child: TextFormField(
                               focusNode: _confirmPasswordFocusNode,
                               keyboardType: TextInputType.visiblePassword,
-                              obscureText: isConfirmPasswordHidden,
+                              obscureText: showConfirmPassword,
                               enabled: true,
                               textInputAction: TextInputAction.done,
                               decoration: textFieldDecoration(
                                 hintText: 'Confirm Password',
                                 suffixIcon: IconButton(
-                                  icon: isConfirmPasswordHidden
-                                      ? const Icon(Icons.visibility_off, color: RelicColors.backgroundColor,)
-                                      : const Icon(Icons.visibility, color: RelicColors.warningColor,),
+                                  icon: showConfirmPassword
+                                      ? const Icon(Icons.visibility)
+                                      : const Icon(Icons.visibility_off),
                                   onPressed: () {
                                     setState(() {
-                                      isConfirmPasswordHidden = !isConfirmPasswordHidden;
+                                      showConfirmPassword = !showConfirmPassword;
                                     });
                                   }, //for show and hide password
                                 ),
@@ -267,17 +266,6 @@ class SignUpScreenState extends State<SignUpScreen> {
                                 child: Image.asset(
                                   'assets/items/google.png',
                                 ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        Center(
-                          child: TextButton(
-                            onPressed: () => Navigator.pop(context),
-                            child: const Text(
-                              'Login',
-                              style: TextStyle(
-                                color: Colors.white,
                               ),
                             ),
                           ),

--- a/lib/views/auth/signup_view.dart
+++ b/lib/views/auth/signup_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:relic_bazaar/helpers/constants.dart';
 import 'package:relic_bazaar/helpers/input_validators.dart';
 import 'package:relic_bazaar/widgets/retro_button.dart';
 import 'package:relic_bazaar/services/auth_service.dart';
@@ -134,8 +135,8 @@ class SignUpScreenState extends State<SignUpScreen> {
                                 hintText: 'Password',
                                 suffixIcon: IconButton(
                                   icon: showPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                      ? const Icon(Icons.visibility_off , color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility , color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(() {
                                       showPassword = !showPassword;
@@ -173,8 +174,8 @@ class SignUpScreenState extends State<SignUpScreen> {
                                 hintText: 'Confirm Password',
                                 suffixIcon: IconButton(
                                   icon: showConfirmPassword
-                                      ? const Icon(Icons.visibility)
-                                      : const Icon(Icons.visibility_off),
+                                      ? const Icon(Icons.visibility_off , color: RelicColors.backgroundColor,)
+                                      : const Icon(Icons.visibility , color: RelicColors.warningColor,),
                                   onPressed: () {
                                     setState(() {
                                       showConfirmPassword = !showConfirmPassword;
@@ -266,6 +267,18 @@ class SignUpScreenState extends State<SignUpScreen> {
                                 child: Image.asset(
                                   'assets/items/google.png',
                                 ),
+                              ),
+
+                            ),
+                          ),
+                        ),
+                        Center(
+                          child: TextButton(
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text(
+                              'Login',
+                              style: TextStyle(
+                                color: Colors.white,
                               ),
                             ),
                           ),

--- a/lib/views/get_user_details_view.dart
+++ b/lib/views/get_user_details_view.dart
@@ -225,11 +225,9 @@ class _GetUserDetailsViewState extends State<GetUserDetailsView> {
               context: context,
             );
           }
-          if(mounted){
-            setState(() {
-              _isLoading = false;
-            });
-          }
+          setState(() {
+            _isLoading = false;
+          });
         });
       }
     }

--- a/lib/views/get_user_details_view.dart
+++ b/lib/views/get_user_details_view.dart
@@ -120,7 +120,7 @@ class _GetUserDetailsViewState extends State<GetUserDetailsView> {
                                 Icons.add_a_photo,
                                 size: 40,
                               )
-                            : Image.file(_image!),
+                            : Image.file(_image! , fit: BoxFit.cover,),
                       ),
                     ),
                     SizedBox(

--- a/lib/views/get_user_details_view.dart
+++ b/lib/views/get_user_details_view.dart
@@ -225,9 +225,11 @@ class _GetUserDetailsViewState extends State<GetUserDetailsView> {
               context: context,
             );
           }
-          setState(() {
-            _isLoading = false;
-          });
+          if(mounted){
+            setState(() {
+              _isLoading = false;
+            });
+          }
         });
       }
     }


### PR DESCRIPTION
### Related Issue
Closes #258 

### Proposed Changes
- Reversed Visibilty Icons on Login form and Sigup form
- Back Link to login page added from sigup page for easier navigaton
- fit type of profile photo updated to cover


### Checklist
- [ x ] Tested
- [ x ] No Conflicts
- [ x ] Change In Code
- [ ] Change In Documentation
- [ x ] Follows linting rules

### Screenshots
Before this PR            | After this PR
:-----------------------: | :-----------------------:
 ![cover bf](https://user-images.githubusercontent.com/53505850/142729481-40200385-3e06-4268-84d3-7858a0afc10c.jpeg) | ![cover af](https://user-images.githubusercontent.com/53505850/142729494-076284f1-962f-487f-8d35-11943e9e928c.jpeg)
Password Field (before) | Password Field (after)
![password bf](https://user-images.githubusercontent.com/53505850/142729597-1b711ab4-3541-4955-a989-eed73a23d553.png)  | ![password bf](https://user-images.githubusercontent.com/53505850/142729643-ada994c4-64e2-430e-a262-4e7bb41c5258.png)
Sign up (before) | Sign up (after)
![signup bf](https://user-images.githubusercontent.com/53505850/142729825-f41fd673-e683-47d6-bdb0-0f23eef9acd2.png) | ![signup af](https://user-images.githubusercontent.com/53505850/142729832-ec9eb1c9-b619-4d84-bf70-e5fd47f3c261.png) 










